### PR TITLE
changing record format to use iso8601 datetimes

### DIFF
--- a/test/execution_test.exs
+++ b/test/execution_test.exs
@@ -17,7 +17,7 @@ defmodule ExecutionTest do
     } = Execution.start(%{user_id: "user-1", post_id: "post-123"})
 
     assert is_binary(event_uuid)
-    assert is_integer(event_time)
+    assert is_struct(event_time)
     assert data.user_id == "user-1"
     assert data.post_id == "post-123"
   end


### PR DESCRIPTION
The `event_time` field needs to be an ISO8601 datetime, as monotonic times can't be handled upstream.