### PR TITLE
handling EXIT, :normal messages in handle_info

### DIFF
--- a/lib/firefighter.ex
+++ b/lib/firefighter.ex
@@ -123,6 +123,11 @@ defmodule Firefighter do
   end
 
   @impl GenServer
+  def handle_info({:EXIT, _from, :normal = reason}, state) do
+    {:stop, reason, state}
+  end
+
+  @impl GenServer
   def terminate(reason, %__MODULE__{timer: timer} = state) do
     Process.cancel_timer(timer)
     Logger.debug("Terminating Firefighter", reason: reason)


### PR DESCRIPTION
According to
https://stackoverflow.com/questions/39430574/unsupervised-gen-server-doesnt-call-terminate-when-it-receives-exit-signal,
there's an edge-case where the terminate callback of genservers might
get bypassed if the exit signal is sent first to the supervisor process,
in which case we have to catch the message and signal termination
ourselves.

Closes #7 