### PR TITLE
More robust data pushing

### DIFF
--- a/lib/execution.ex
+++ b/lib/execution.ex
@@ -1,4 +1,6 @@
 defmodule Firefighter.Execution do
+  require Logger
+
   @type execution :: %__MODULE__{}
 
   @callback start(data :: map) :: execution
@@ -58,13 +60,23 @@ defmodule Firefighter.Execution do
   end
 
   defp to_record(%__MODULE__{event_uuid: event_uuid, event_time: event_time, data: data}) do
-    %{
-      event_uuid: event_uuid,
-      event_time: event_time |> DateTime.to_iso8601(),
-      elapsed: DateTime.diff(current_time(), event_time)
-    }
-    |> Map.merge(data)
-    |> json().encode!()
+    record =
+      %{
+        event_uuid: event_uuid,
+        event_time: event_time |> DateTime.to_iso8601(),
+        elapsed: DateTime.diff(current_time(), event_time)
+      }
+      |> Map.merge(data)
+      |> json().encode()
+
+    case record do
+      {:ok, json_string} ->
+        json_string
+
+      {:error, error} ->
+        Logger.error("Failed to JSON encode", error: error, record: inspect(record))
+        nil
+    end
   end
 
   defp uuid, do: UUID.uuid4()

--- a/lib/firefighter.ex
+++ b/lib/firefighter.ex
@@ -89,6 +89,11 @@ defmodule Firefighter do
   end
 
   @impl GenServer
+  def handle_cast({:push, nil}, %__MODULE__{} = state) do
+    {:noreply, state}
+  end
+
+  @impl GenServer
   def handle_cast({:push, record}, %__MODULE__{records: records} = state) do
     records = :queue.in(record, records)
     {:noreply, %{state | records: records}}

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,7 +1,8 @@
 import Mox
 
 defmodule JasonBehaviour do
-  @callback encode!(map()) :: binary()
+  @callback encode(any()) ::
+              {:ok, String.t()} | {:error, Jason.EncodeError.t() | Exception.t()}
 end
 
 defmock(Firefighter.FirehoseMock, for: Firefighter.Adapter)


### PR DESCRIPTION
Prevent Firefighter.Execution from failing catastrophically if complex
object being JSON-serialized is not JSON-serializable via the JSON
library adapter used.

Closes #9